### PR TITLE
converted detection of no_data=null to a warning

### DIFF
--- a/src/data_validation/custom_primary_validator.py
+++ b/src/data_validation/custom_primary_validator.py
@@ -159,9 +159,9 @@ def evaluate_custom_primary_config(non_tiled_city_data, existing_tiles_metrics):
             if full_metrics_df['nodata'].isnull().any():
                 files_with_nan = full_metrics_df.loc[full_metrics_df['nodata'].isnull(), 'filename'].tolist()
                 files_with_nan_str = ','.join(map(str,files_with_nan))
-                msg = (f"Folder {tile_folder_name} and possibly other folders has forbidden no_data='nan' "
-                       f"in file(s) ({files_with_nan_str}).")
-                invalids.append((msg, True))
+                msg = (f"Tile {tile_folder_name} has no_data='nan' in file(s) ({files_with_nan_str}). This can lead "
+                       f"to unexpected or invalid results.")
+                invalids.append((msg, False))
 
             if 'lulc' in custom_primary_features:
                 lulc_metrics = full_metrics_df.loc[full_metrics_df['filename'] == tiled_city_data.lulc_tif_filename]

--- a/src/data_validation/manager.py
+++ b/src/data_validation/manager.py
@@ -48,19 +48,23 @@ def _invalid_has_fatal_error(detailed_invalids):
     return has_fatal_error
 
 
-def _print_invalids(invalids):
-    i=1
-    for invalid in invalids:
-        print(f'{i}) {invalid[0]}')
-        i +=1
-
-
 def print_invalids(invalids):
     head_msg = ' vvvvvvvvvvvv Invalid configurations vvvvvvvvvvvv '
     tail_msg = ' ^^^^^^^^^^^^ Invalid configurations ^^^^^^^^^^^^ '
 
     print('\n')
     print(head_msg)
-    _print_invalids(invalids)
+    _print_invalid_statements(invalids)
     print(tail_msg)
     print('\n')
+
+
+def _print_invalid_statements(invalids):
+    i=1
+    for invalid in invalids:
+        is_failure = invalid[1]
+        if is_failure:
+            print(f'({i}) ERROR: {invalid[0]}')
+        else:
+            print(f'({i}) WARNING: {invalid[0]}')
+        i +=1


### PR DESCRIPTION
Tested locally

## What is the new behavior?
TIFF files with no_data=nan will now be identified as a validation warning instead of failure.