### PR TITLE
Cdb 337 specified tree light transmissivity not passed to umep

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release notes for cities-thermal-comfort-modeling (CTCM) processing framework
 
+## 2025/06/05
+1. CDB-337. Fixed bug of not passing the configured values for transmissivity_of_light_through_vegetation and trunk_tree_height to skyview-factor UMEP plugin.
+
 ## 2025/05/29
 1. Added generation and handling of open_urban primary file.
 1. Changed error message to a warning for when the actual AOI differs by a large distance from stated AOI in the config yml file.

--- a/src/workers/umep_plugin_processor.py
+++ b/src/workers/umep_plugin_processor.py
@@ -135,9 +135,9 @@ def _prepare_method_execution(method, tiled_city_data, tmpdirname, metadata_logg
         method_params = {
             'INPUT_DSM': tiled_city_data.target_dsm_path,
             'INPUT_CDSM': tiled_city_data.target_tree_canopy_path,
-            'TRANS_VEG': 3,
+            'TRANS_VEG': tiled_city_data.light_transmissivity,
             'INPUT_TDSM': None,
-            'INPUT_THEIGHT': 25,
+            'INPUT_THEIGHT': tiled_city_data.trunk_zone_height,
             'ANISO': True,
             'OUTPUT_DIR': tmpdirname,
             'OUTPUT_FILE': temp_svfs_file_no_extension


### PR DESCRIPTION
See https://gfw.atlassian.net/browse/CDB-337.

Added two missing specifications for skyview-factor plugin.