### PR TITLE
Align local tile output layout with S3 structure

### DIFF
--- a/src/workers/city_data.py
+++ b/src/workers/city_data.py
@@ -134,12 +134,12 @@ class CityData:
             obj.target_tcm_results_path = os.path.join(obj.target_city_path, FOLDER_NAME_UMEP_TCM_RESULTS)
 
             if obj.folder_name_tile_data:
+                obj.target_tile_path = os.path.join(obj.target_city_path, obj.folder_name_tile_data)
                 metadata_file_name = f'{obj.folder_name_tile_data}_metadata.log'
                 obj.target_umep_metadata_log_path = os.path.join(obj.target_log_path, 'model_metadata', metadata_file_name)
 
-                obj.target_raster_files_path = os.path.join(obj.target_city_primary_data_path,
-                                                            FOLDER_NAME_PRIMARY_RASTER_FILES)
-                obj.target_primary_tile_data_path = os.path.join(obj.target_raster_files_path, obj.folder_name_tile_data)
+                obj.target_raster_files_path = os.path.join(obj.target_tile_path, FOLDER_NAME_PRIMARY_RASTER_FILES)
+                obj.target_primary_tile_data_path = obj.target_raster_files_path
 
                 obj.target_albedo_cloud_masked_path = os.path.join(obj.target_primary_tile_data_path,
                                                            obj.albedo_cloud_masked_tif_filename)
@@ -150,7 +150,8 @@ class CityData:
                 obj.target_tree_canopy_path = os.path.join(obj.target_primary_tile_data_path,
                                                            obj.tree_canopy_tif_filename)
 
-                obj.target_intermediate_tile_data_path = os.path.join(obj.target_intermediate_data_path, obj.folder_name_tile_data)
+                obj.target_intermediate_tile_data_path = os.path.join(obj.target_tile_path, FOLDER_NAME_INTERMEDIATE_DATA)
+                obj.target_tcm_results_path = os.path.join(obj.target_tile_path, FOLDER_NAME_UMEP_TCM_RESULTS)
                 obj.target_wallheight_path = os.path.join(obj.target_intermediate_tile_data_path, obj.wall_height_filename)
                 obj.target_wallaspect_path = os.path.join(obj.target_intermediate_tile_data_path, obj.wall_aspect_filename)
                 obj.target_svfszip_path = os.path.join(obj.target_intermediate_tile_data_path, obj.skyview_factor_filename)

--- a/src/workers/model_umep/umep_plugin_processor.py
+++ b/src/workers/model_umep/umep_plugin_processor.py
@@ -151,7 +151,7 @@ def _prepare_method_execution(method, tiled_city_data, tmpdirname, metadata_logg
         target_met_file_path = os.path.join(tiled_city_data.target_met_files_path, met_filename)
         temp_met_folder = os.path.join(tmpdirname, Path(met_filename).stem, tiled_city_data.folder_name_tile_data)
         create_folder(temp_met_folder)
-        target_met_folder = os.path.join(tiled_city_data.target_tcm_results_path, Path(met_filename).stem, tiled_city_data.folder_name_tile_data)
+        target_met_folder = os.path.join(tiled_city_data.target_tcm_results_path, Path(met_filename).stem)
         method_params = {
             "INPUT_DSM": tiled_city_data.target_dsm_path,
             "INPUT_SVF": tiled_city_data.target_svfszip_path,

--- a/src/workers/model_upenn/upenn_module_processor.py
+++ b/src/workers/model_upenn/upenn_module_processor.py
@@ -149,7 +149,7 @@ def _prepare_method_execution(method, tiled_city_data, tmpdirname, metadata_logg
         target_met_file_path = os.path.join(tiled_city_data.target_met_files_path, met_filename)
         temp_met_folder = os.path.join(tmpdirname, Path(met_filename).stem, tiled_city_data.folder_name_tile_data)
         create_folder(temp_met_folder)
-        target_met_folder = os.path.join(tiled_city_data.target_tcm_results_path, Path(met_filename).stem, tiled_city_data.folder_name_tile_data)
+        target_met_folder = os.path.join(tiled_city_data.target_tcm_results_path, Path(met_filename).stem)
         method_params = {
             "INPUT_DSM": tiled_city_data.target_dsm_path,
             "INPUT_SVF": tiled_city_data.target_svfszip_path,

--- a/src/workers/worker_dao.py
+++ b/src/workers/worker_dao.py
@@ -152,12 +152,12 @@ def cache_tile_files(tiled_city_data:CityData):
     # Cache primary raster
     local_folder = tiled_city_data.target_raster_files_path
     s3_folder_uri = f"{tile_folder_key}/{FOLDER_NAME_PRIMARY_RASTER_FILES}"
-    _process_tile_folder(local_folder, tile_id, bucket_name, s3_folder_uri, publishing_target, '.tif')
+    _process_tile_folder(local_folder, None, bucket_name, s3_folder_uri, publishing_target, '.tif')
 
     # Cache intermediate files
-    local_folder = tiled_city_data.target_intermediate_data_path
+    local_folder = tiled_city_data.target_intermediate_tile_data_path
     s3_folder_uri = f"{tile_folder_key}/{FOLDER_NAME_INTERMEDIATE_DATA}"
-    _process_tile_folder(local_folder, tile_id, bucket_name, s3_folder_uri, publishing_target, '.tif')
+    _process_tile_folder(local_folder, None, bucket_name, s3_folder_uri, publishing_target, '.tif')
 
     # Cache tcm results
     tcm_path = tiled_city_data.target_tcm_results_path
@@ -165,7 +165,13 @@ def cache_tile_files(tiled_city_data:CityData):
     for met_folder in met_folders:
         local_folder = os.path.join(tiled_city_data.target_tcm_results_path, met_folder)
         s3_folder_uri = f"{tile_folder_key}/{FOLDER_NAME_UMEP_TCM_RESULTS}/{met_folder}"
-        _process_tile_folder(local_folder, tile_id, bucket_name, s3_folder_uri, publishing_target, extension_filter='.tif')
+        _process_tile_folder(local_folder, None, bucket_name, s3_folder_uri, publishing_target, extension_filter='.tif')
+
+    if publishing_target == 's3':
+        remove_folder(tiled_city_data.target_tile_path)
+        notice_file = os.path.join(tiled_city_data.target_city_path, f"{tile_id}_contents_cached_to_s3.txt")
+        with open(notice_file, "w") as file:
+            pass
 
 
 def identify_tiles_with_partial_file_set(non_tiled_city_data: CityData):

--- a/src/workers/worker_tile_processor.py
+++ b/src/workers/worker_tile_processor.py
@@ -137,7 +137,7 @@ def process_tile(city_json_str, processing_method, source_base_path, target_base
         # Remove buffered area from mrt results
         buffer_meters = tiled_city_data.tile_buffer_meters
         if len(custom_primary_features) == 0 and tiled_city_data.remove_mrt_buffer_for_final_output is True:
-            _trim_mrt_buffer(target_tcm_results_path, tile_folder_name, met_filenames, tile_boundary, buffer_meters)
+            _trim_mrt_buffer(target_tcm_results_path, met_filenames, tile_boundary, buffer_meters)
 
     # Cache project files in S3
     if tiled_city_data.city_json_str is not None and tiled_city_data.publishing_target in ('s3', 'both'):
@@ -150,7 +150,7 @@ def process_tile(city_json_str, processing_method, source_base_path, target_base
     return result_json
 
 
-def _trim_mrt_buffer(target_tcm_results_path, tile_folder_name, met_filenames, tile_boundary, buffer_meters):
+def _trim_mrt_buffer(target_tcm_results_path, met_filenames, tile_boundary, buffer_meters):
     """
     See https://gfw.atlassian.net/browse/CDB-182 for logic behind this function.
     Briefly, the concept is that the code buffers out some hundreds of meters from a tiled area and then clips back to
@@ -175,7 +175,7 @@ def _trim_mrt_buffer(target_tcm_results_path, tile_folder_name, met_filenames, t
 
     for met_filename in met_filenames:
         file_stem = Path(met_filename).stem
-        tile_path = str(os.path.join(target_tcm_results_path, file_stem, tile_folder_name))
+        tile_path = str(os.path.join(target_tcm_results_path, file_stem))
         for file in os.listdir(tile_path):
             if file.endswith('.tif'):
                 file_path = os.path.join(tile_path, file)


### PR DESCRIPTION
### Motivation
- Local tiled output layout did not match the S3 per-tile layout, making local-to-S3 copying and validation difficult. 
- The change ensures local runs produce the same per-tile directory hierarchy as S3 so outputs can be copied or compared reliably.

### Description
- Add `target_tile_path` and move primary, intermediate and TCM result targets under the per-tile folder by updating `target_raster_files_path`, `target_intermediate_tile_data_path`, and `target_tcm_results_path` in `src/workers/city_data.py`.
- Adjust met/result target folder logic in `src/workers/model_umep/umep_plugin_processor.py` and `src/workers/model_upenn/upenn_module_processor.py` to use the new tile-rooted `target_tcm_results_path` (remove the extra per-tile join from `target_met_folder`).
- Update buffer-trim logic in `src/workers/worker_tile_processor.py` by changing `_trim_mrt_buffer` to operate on the new per-met folders (signature and path construction updated).
- Change `cache_tile_files` in `src/workers/worker_dao.py` to upload files from the new tile-rooted local layout (use `target_intermediate_tile_data_path`, call `_process_tile_folder` without per-file `tile_id`), and remove local tile folders when publishing only to S3.

### Testing
- No automated tests were run on these changes.
- Changes were committed locally and verified by file diffs; no CI/unit test results are available in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d21b2b79883318b2af562ea64ad22)